### PR TITLE
Fix #1

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const newline = '\n';
 function nl2br(text) {
     if (typeof text === 'number') {
         return text;
-    } else if (typeof text !== 'string') {
+    } else if (typeof text !== 'string' || text === '') {
         return '';
     }
 

--- a/test/nl2br_test.js
+++ b/test/nl2br_test.js
@@ -58,4 +58,10 @@ describe('nl2br', function(){
         const expected = '';
         assert.deepEqual(expected, result);
     });
+
+    it('should return an empty string if the param is an empty string', function () {
+        const result = nl2br('');
+        const expected = '';
+        assert.deepEqual(expected, result);
+    });
 });


### PR DESCRIPTION
`"".split(newline)` is apparently `[""]` which is why the bug happens

Fixes #1